### PR TITLE
Changed AutoVectorize to use return by value for better performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(SOURCE_FILES "src/main.cpp")
 
-set(CMAKE_CXX_FLAGS "-O0")
+set(CMAKE_CXX_FLAGS "-O1")
 add_executable(sseneoncompare ${SOURCE_FILES})
 target_link_libraries(sseneoncompare bbox4 bbox4_autovec)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
 
     timer.start();
     for (int i = 0; i < numTests; i++) {
-        rayBBoxIntersect4AutoVectorize(ray, bbox4, hits, tMins, tMaxs);
+        std::tie(hits, tMins, tMaxs) = rayBBoxIntersect4AutoVectorize(ray, bbox4);
     }
     printResults("Autovectorize", timer.getElapsedTime(), hits, tMins, tMaxs);
 

--- a/src/sseneoncompare.hpp
+++ b/src/sseneoncompare.hpp
@@ -3,6 +3,7 @@
 #define SSENEONCOMPARE_HPP
 
 #include <cmath>
+#include <tuple>
 
 #if defined(__x86_64__)
 #include <xmmintrin.h>
@@ -183,11 +184,8 @@ void rayBBoxIntersect4Neon(const Ray& ray,
 #endif
 
 // Compact scalar version written to be easily autovectorized
-void rayBBoxIntersect4AutoVectorize(const Ray& ray,
-                                    const BBox4& bbox4,
-                                    IVec4& hits,
-                                    FVec4& tMins,
-                                    FVec4& tMaxs);
+std::tuple<IVec4,FVec4,FVec4> rayBBoxIntersect4AutoVectorize(const Ray& ray,
+                                    const BBox4& bbox4);
 
 // Wrapper to call ISPC version of the compact Williams et al. 2005 implementation
 void rayBBoxIntersect4ISPC(const Ray& ray,

--- a/src/sseneoncompare_autovec.cpp
+++ b/src/sseneoncompare_autovec.cpp
@@ -1,50 +1,47 @@
 #include "sseneoncompare.hpp"
 
 // Compact scalar version written to be easily autovectorized
-void rayBBoxIntersect4AutoVectorize(const Ray& ray,
-                                    const BBox4& bbox4,
-                                    IVec4& hits,
-                                    FVec4& tMins,
-                                    FVec4& tMaxs) {
-    float rdir[3] = { 1.0f / ray.direction.x, 1.0f / ray.direction.y, 1.0f / ray.direction.z };
-    float rdirX[4] = { rdir[0], rdir[0], rdir[0], rdir[0] };
-    float rdirY[4] = { rdir[1], rdir[1], rdir[1], rdir[1] };
-    float rdirZ[4] = { rdir[2], rdir[2], rdir[2], rdir[2] };
-    float originX[4] = { ray.origin.x, ray.origin.x, ray.origin.x, ray.origin.x };
-    float originY[4] = { ray.origin.y, ray.origin.y, ray.origin.y, ray.origin.y };
-    float originZ[4] = { ray.origin.z, ray.origin.z, ray.origin.z, ray.origin.z };
-    float rtMin[4] = { ray.tMin, ray.tMin, ray.tMin, ray.tMin };
-    float rtMax[4] = { ray.tMax, ray.tMax, ray.tMax, ray.tMax };
+std::tuple<IVec4,FVec4,FVec4> rayBBoxIntersect4AutoVectorize(const Ray& ray,
+                                    const BBox4& bbox4) {
 
-    IVec4 near(int(rdir[0] >= 0.0f ? 0 : 3), int(rdir[1] >= 0.0f ? 1 : 4),
-               int(rdir[2] >= 0.0f ? 2 : 5));
-    IVec4 far(int(rdir[0] >= 0.0f ? 3 : 0), int(rdir[1] >= 0.0f ? 4 : 1),
-              int(rdir[2] >= 0.0f ? 5 : 2));
+    float rdirX = 1.0f / ray.direction.x;
+    float rdirY = 1.0f / ray.direction.y;
+    float rdirZ = 1.0f / ray.direction.z;
 
-    float product0[4];
+    IVec4 near(int(rdirX >= 0.0f ? 0 : 3), int(rdirY >= 0.0f ? 1 : 4),
+               int(rdirZ >= 0.0f ? 2 : 5));
+    IVec4 far(int(rdirX >= 0.0f ? 3 : 0), int(rdirY >= 0.0f ? 4 : 1),
+              int(rdirZ >= 0.0f ? 5 : 2));
+
+    IVec4 hits = IVec4();
+    FVec4 tMins = FVec4();
+    FVec4 tMaxs = FVec4();
 
 #pragma clang loop vectorize(enable)
     for (int i = 0; i < 4; i++) {
-        product0[i] = bbox4.corners[near.y][i] - originY[i];
-        tMins[i] = bbox4.corners[near.z][i] - originZ[i];
-        product0[i] = product0[i] * rdirY[i];
-        tMins[i] = tMins[i] * rdirZ[i];
-        product0[i] = fmax(product0[i], tMins[i]);
-        tMins[i] = bbox4.corners[near.x][i] - originX[i];
-        tMins[i] = tMins[i] * rdirX[i];
-        tMins[i] = fmax(rtMin[i], tMins[i]);
-        tMins[i] = fmax(product0[i], tMins[i]);
+        float product0 = bbox4.corners[near.y][i] - ray.origin.y;
+        float tmin = bbox4.corners[near.z][i] - ray.origin.z;
+        product0 = product0 * rdirY;
+        tmin = rdirZ * tmin;
+        product0 = fmax(product0, tmin);
+        tmin = bbox4.corners[near.x][i] - ray.origin.x;
+        tmin = tmin * rdirX;
+        tmin = fmax(ray.tMin, tmin);
+        tmin = fmax(product0, tmin);
 
-        product0[i] = bbox4.corners[far.y][i] - originY[i];
-        tMaxs[i] = bbox4.corners[far.z][i] - originZ[i];
-        product0[i] = product0[i] * rdirY[i];
-        tMaxs[i] = tMaxs[i] * rdirZ[i];
-        product0[i] = fmin(product0[i], tMaxs[i]);
-        tMaxs[i] = bbox4.corners[far.x][i] - originX[i];
-        tMaxs[i] = tMaxs[i] * rdirX[i];
-        tMaxs[i] = fmin(rtMax[i], tMaxs[i]);
-        tMaxs[i] = fmin(product0[i], tMaxs[i]);
+        product0 = bbox4.corners[far.y][i] - ray.origin.y;
+        float tmax = bbox4.corners[far.z][i] - ray.origin.z;
+        product0 = product0 * rdirY;
+        tmax = tmax * rdirZ;
+        product0 = fmin(product0, tmax);
+        tmax = bbox4.corners[far.x][i] - ray.origin.x;
+        tmax = tmax * rdirX;
+        tmax = fmin(ray.tMax, tmax);
+        tmax = fmin(product0, tmax);
 
+        tMaxs[i] = tmax;
+        tMins[i] = tmin;
         hits[i] = tMins[i] <= tMaxs[i];
     }
+    return std::make_tuple(hits,tMins,tMaxs);
 }


### PR DESCRIPTION
It's a proof of concept that shows that the auto vectorizer can create similar performance than the manual SSE and ISPC.

The issue with the return by ref is that the optimizer, is bad at making assumptions about memory. Also in general the optimizer is very good at widening, but doing so manually might irritate him more, because of it not being in the compilers canonicalized form for widening.

Also changed to -O1 for main.cpp. It is mostly required to get rid of tuple boilerplate. And return by value by itself often benefits from having optimizations for the Caller.
Also checked the ASM: AutoVectorize doesn't get inlined and gets no benefit this way.

The pull request "as is" isn't really made to be merged. More to show that the vectorizer goes a long way, when the code is structured the correct way for the optimizer.

My local numbers are:
```
SSE: 10.8873 ns average
  Total time for 100000 runs: 1088.73 μs
  ...

Autovectorize: 9.08702 ns average
  Total time for 100000 runs: 908.702 μs
  ...

ISPC: 10.2582 ns average
  Total time for 100000 runs: 1025.81 μs
  ...
```